### PR TITLE
Broaden CMR search defaults and reuse server graph

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 OPENAI_API_KEY=your_openai_key_here
 ANTHROPIC_API_KEY=your_anthropic_key_here
 CMR_BASE_URL=https://cmr.earthdata.nasa.gov
-CMR_PROVIDER=CMR
+CMR_PROVIDER=ALL
 VECTOR_DB_PATH=./vectordb/index.faiss
 VECTOR_DB_DIR=./vectordb/chroma

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## NASA CMR AI Agent (LangGraph)
 
 ### Overview
-An async, multi‑agent LangGraph pipeline that interprets natural‑language queries, validates intent, queries NASA CMR (collections/granules), performs lightweight analysis, retrieves semantic context from a local Chroma vector store, and synthesizes responses. Server exposes `/query` and `/stream` endpoints.
+An async, multi‑agent LangGraph pipeline that interprets natural‑language queries, infers temporal/spatial bounds, queries NASA CMR (collections/granules/variables), performs coverage analysis (temporal range & spatial extent), retrieves semantic context from a local Chroma vector store, maintains simple session memory, and synthesizes responses. Server exposes `/query` and `/stream` endpoints.
 
 ### Quickstart
 1) Create and activate a virtual env, then install deps:
@@ -18,8 +18,8 @@ pip install -r requirements.txt
 ```dotenv
 OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=...
-# For broad discovery, avoid over-restricting provider:
-CMR_PROVIDER=ALL
+# Optional: restrict CMR provider (defaults to ALL)
+# CMR_PROVIDER=CMR
 ```
 
 3) Run tests:
@@ -41,8 +41,8 @@ uvicorn server.main:app --host 127.0.0.1 --port 8000
 ```
 
 Endpoints:
-- `GET /query?query=...` returns final graph state (JSON)
-- `GET /stream?query=...` streams step events (text/event-stream)
+- `GET /query?query=...&session_id=...` returns final graph state (JSON) and preserves per-session history
+- `GET /stream?query=...&session_id=...` streams step events (text/event-stream)
 
 ### Project structure
 

--- a/cmr_agent/agents/analysis_agent.py
+++ b/cmr_agent/agents/analysis_agent.py
@@ -1,23 +1,103 @@
 from __future__ import annotations
-from typing import Any, Dict
+from typing import Any, Dict, List
 from datetime import datetime
 
 class AnalysisAgent:
     async def run(self, cmr_results: dict) -> dict:
         searches = cmr_results.get('searches', []) if isinstance(cmr_results, dict) else []
-        summary: dict[str, Any] = {'total_collections': 0, 'total_granules': 0, 'queries': []}
+        summary: dict[str, Any] = {
+            'total_collections': 0,
+            'total_granules': 0,
+            'total_variables': 0,
+            'queries': [],
+        }
         for s in searches:
             cols = (s.get('collections') or {}).get('items', [])
             grans = (s.get('granules') or {}).get('items', [])
+            vars = (s.get('variables') or {}).get('items', [])
             summary['total_collections'] += len(cols)
             summary['total_granules'] += len(grans)
+            summary['total_variables'] += len(vars)
+
             providers = {((c.get('meta') or {}).get('provider-id') or 'unknown') for c in cols}
-            titles = [(c.get('umm') or {}).get('ShortName') or (c.get('umm') or {}).get('LongName') for c in cols[:5]]
+            titles = [
+                (c.get('umm') or {}).get('ShortName') or (c.get('umm') or {}).get('LongName')
+                for c in cols[:5]
+            ]
+
+            # temporal coverage and spatial extent from granules
+            start: datetime | None = None
+            end: datetime | None = None
+            bbox: List[float] | None = None  # [west, south, east, north]
+            for g in grans:
+                umm = g.get('umm') or {}
+
+                te = (umm.get('TemporalExtent') or {}).get('RangeDateTime')
+                if te:
+                    try:
+                        b = datetime.fromisoformat(te.get('BeginningDateTime').replace('Z', '+00:00'))
+                        e = datetime.fromisoformat(te.get('EndingDateTime').replace('Z', '+00:00'))
+                        start = b if start is None or b < start else start
+                        end = e if end is None or e > end else end
+                    except Exception:
+                        pass
+
+                se = (umm.get('SpatialExtent') or {})
+                geom = (se.get('HorizontalSpatialDomain') or {}).get('Geometry') or {}
+                boxes = geom.get('BoundingBox') or geom.get('BoundingRectangles') or []
+                if isinstance(boxes, dict):
+                    boxes = [boxes]
+                for box in boxes:
+                    try:
+                        w = float(box.get('WestBoundingCoordinate'))
+                        s_ = float(box.get('SouthBoundingCoordinate'))
+                        e_ = float(box.get('EastBoundingCoordinate'))
+                        n = float(box.get('NorthBoundingCoordinate'))
+                        if bbox is None:
+                            bbox = [w, s_, e_, n]
+                        else:
+                            bbox = [
+                                min(bbox[0], w),
+                                min(bbox[1], s_),
+                                max(bbox[2], e_),
+                                max(bbox[3], n),
+                            ]
+                    except Exception:
+                        continue
+
+            coverage = {}
+            if start and end:
+                coverage = {
+                    'start': start.strftime('%Y-%m-%d'),
+                    'end': end.strftime('%Y-%m-%d'),
+                }
+
+            spatial = {}
+            if bbox:
+                spatial = {'bbox': bbox}
+
+            example_vars: List[str] = []
+            related: List[str] = []
+            for v in vars[:5]:
+                name = (v.get('umm') or {}).get('Name')
+                if name:
+                    example_vars.append(name)
+                assocs = (v.get('associations') or {}).get('collections', [])
+                for a in assocs:
+                    cid = a.get('concept_id')
+                    if cid:
+                        related.append(cid)
+
             summary['queries'].append({
                 'query': s.get('query'),
                 'collections_found': len(cols),
                 'granules_found': len(grans),
+                'variables_found': len(vars),
                 'providers': sorted([p for p in providers if p]),
                 'example_collections': [t for t in titles if t],
+                'example_variables': example_vars,
+                'temporal_coverage': coverage,
+                'spatial_extent': spatial,
+                'related_collections': sorted(set(related)),
             })
         return summary

--- a/cmr_agent/agents/cmr_agent.py
+++ b/cmr_agent/agents/cmr_agent.py
@@ -1,31 +1,12 @@
 from __future__ import annotations
-import re, asyncio
-from datetime import datetime
-from typing import Any, Dict, Tuple
+
+import asyncio
+from typing import Any, Dict
+
 from cmr_agent.cmr.client import AsyncCMRClient
 from cmr_agent.config import settings
+from cmr_agent.utils import infer_temporal, infer_bbox
 
-REGION_TO_BBOX = {
-    'sub-saharan africa': (-20.0, -35.0, 52.0, 20.0),
-    'ssa': (-20.0, -35.0, 52.0, 20.0),
-    'global': (-180.0, -90.0, 180.0, 90.0),
-}
-
-def infer_temporal(text: str) -> Tuple[str | None, str | None]:
-    # capture full 4-digit years 1900-2099
-    years = [int(y) for y in re.findall(r"((?:19|20)\d{2})", text)]
-    if len(years) >= 2:
-        years.sort()
-        return f"{years[0]}-01-01T00:00:00Z", f"{years[-1]}-12-31T23:59:59Z"
-    return None, None
-
-def infer_bbox(text: str) -> Tuple[float, float, float, float] | None:
-    lowered = text.lower()
-    for key, bbox in REGION_TO_BBOX.items():
-        if key in lowered:
-            w, s, e, n = bbox
-            return w, s, e, n
-    return None
 
 class CMRAgent:
     def __init__(self):
@@ -36,43 +17,51 @@ class CMRAgent:
             temporal = infer_temporal(q)
             bbox = infer_bbox(q)
             params: Dict[str, Any] = {
-                'page_size': 25,
-                'keyword': q,
+                "page_size": 25,
+                "keyword": q,
             }
-            # Only constrain provider if configured differently than default 'CMR_ALL'
-            provider = getattr(settings, 'cmr_provider', None)
-            if provider and provider not in ('', 'ALL', 'CMR_ALL'):
-                params['provider'] = provider
+            provider = getattr(settings, "cmr_provider", None)
+            if provider and provider not in ("", "ALL", "CMR_ALL"):
+                params["provider"] = provider
             if temporal[0] and temporal[1]:
-                params['temporal'] = f"{temporal[0]},{temporal[1]}"
+                params["temporal"] = f"{temporal[0]},{temporal[1]}"
             if bbox:
                 w, s, e, n = bbox
-                params['bounding_box'] = f"{w},{s},{e},{n}"
+                params["bounding_box"] = f"{w},{s},{e},{n}"
+
             collections_task = self.client.search_collections(params)
+
             async def granules(params: Dict[str, Any]) -> dict:
                 try:
                     cols = await collections_task
-                    items = (cols or {}).get('items', [])
+                    items = (cols or {}).get("items", [])
                     if items:
-                        concept_ids = [i.get('meta', {}).get('concept-id') for i in items if i.get('meta')]
+                        concept_ids = [i.get("meta", {}).get("concept-id") for i in items if i.get("meta")]
                         gid = concept_ids[0]
-                        gparams = {k: v for k, v in params.items() if k != 'page_size'}
+                        gparams = {k: v for k, v in params.items() if k != "page_size"}
                         if gid:
-                            gparams['collection_concept_id'] = gid
-                        gparams['page_size'] = 50
+                            gparams["collection_concept_id"] = gid
+                        gparams["page_size"] = 50
                         return await self.client.search_granules(gparams)
                 except Exception:
                     pass
-                return {'items': []}
-            results = await asyncio.gather(collections_task, granules(params), return_exceptions=True)
-            collections, granules_res = results
+                return {"items": []}
+
+            variables_task = self.client.search_variables({"keyword": q, "page_size": 25})
+
+            results = await asyncio.gather(
+                collections_task, granules(params), variables_task, return_exceptions=True
+            )
+            collections, granules_res, variables_res = results
             return {
-                'query': q,
-                'collections': collections if isinstance(collections, dict) else {'error': str(collections)},
-                'granules': granules_res if isinstance(granules_res, dict) else {'error': str(granules_res)},
+                "query": q,
+                "collections": collections if isinstance(collections, dict) else {"error": str(collections)},
+                "granules": granules_res if isinstance(granules_res, dict) else {"error": str(granules_res)},
+                "variables": variables_res if isinstance(variables_res, dict) else {"error": str(variables_res)},
             }
+
         searches = await asyncio.gather(*(search_for(q) for q in (subqueries or [query])))
-        return {'searches': searches}
+        return {"searches": searches}
 
     async def close(self):
         await self.client.close()

--- a/cmr_agent/agents/intent_agent.py
+++ b/cmr_agent/agents/intent_agent.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import List, Tuple
 import re
 from cmr_agent.types import IntentType
 
@@ -35,7 +34,7 @@ class IntentAgent:
             parts = [p.strip() for p in re.split(r"[,;]|\band\b", query) if p.strip()]
             return intent, parts or [query]
 
-        import json, re
+        import json
         prompt = f"{SYSTEM_PROMPT}\nQuery: {query}\nRespond as JSON with keys: intent, subqueries."
         msg = await self.llm.ainvoke(prompt)
         content = getattr(msg, 'content', str(msg))

--- a/cmr_agent/agents/synthesis_agent.py
+++ b/cmr_agent/agents/synthesis_agent.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any
+from typing import Any, List
 
 class SynthesisAgent:
     def __init__(self):
@@ -14,18 +14,22 @@ class SynthesisAgent:
             self.router = None
             self.llm = None
 
-    async def run(self, query: str, analysis: dict) -> str:
+    async def run(self, query: str, analysis: dict, history: List[str]) -> str:
         if self.llm is None:
             # Templated fallback
             parts = [
                 f"Query: {query}",
                 f"Total collections: {analysis.get('total_collections', 0)}",
                 f"Total granules: {analysis.get('total_granules', 0)}",
+                f"Total variables: {analysis.get('total_variables', 0)}",
             ]
             for q in analysis.get('queries', [])[:3]:
-                parts.append(
-                    f"- '{q.get('query')}' -> collections={q.get('collections_found')}, granules={q.get('granules_found')}, providers={','.join(q.get('providers', []))}"
-                )
+                line = f"- '{q.get('query')}' -> collections={q.get('collections_found')}, granules={q.get('granules_found')}, providers={','.join(q.get('providers', []))}"
+                tc = q.get('temporal_coverage')
+                if tc:
+                    line += f", coverage={tc.get('start')} to {tc.get('end')}"
+                parts.append(line)
+            parts.append(f"Session memory: {len(history)-1} previous queries")
             parts.append("Recommendations: refine temporal/spatial filters and select collections with consistent coverage.")
             return "\n".join(parts)
         prompt = (

--- a/cmr_agent/config.py
+++ b/cmr_agent/config.py
@@ -5,7 +5,7 @@ class Settings(BaseSettings):
     openai_api_key: str | None = Field(default=None, alias='OPENAI_API_KEY')
     anthropic_api_key: str | None = Field(default=None, alias='ANTHROPIC_API_KEY')
     cmr_base_url: str = Field(default='https://cmr.earthdata.nasa.gov', alias='CMR_BASE_URL')
-    cmr_provider: str = Field(default='CMR', alias='CMR_PROVIDER')
+    cmr_provider: str = Field(default='ALL', alias='CMR_PROVIDER')
     vector_db_dir: str = Field(default='./vectordb/chroma', alias='VECTOR_DB_DIR')
 
     class Config:

--- a/cmr_agent/types.py
+++ b/cmr_agent/types.py
@@ -12,6 +12,9 @@ class QueryState(TypedDict, total=False):
     analysis: dict
     synthesis: str
     context: dict
+    temporal: tuple[str, str]
+    bbox: tuple[float, float, float, float]
+    history: list[str]
 
 class AgentResult(TypedDict, total=False):
     name: str

--- a/cmr_agent/utils.py
+++ b/cmr_agent/utils.py
@@ -1,8 +1,51 @@
+"""Utility helpers for the CMR agent system."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
 from tenacity import retry, stop_after_attempt, wait_exponential
-from typing import Callable, TypeVar, Any
+from typing import Callable, TypeVar, Any, Tuple
 
 T = TypeVar('T')
 
+
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=0.5, min=0.5, max=4))
 def with_retry(fn: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Execute ``fn`` with basic retry semantics."""
     return fn(*args, **kwargs)
+
+
+# Simple geographic shorthands to bounding boxes (W,S,E,N)
+REGION_TO_BBOX = {
+    'sub-saharan africa': (-20.0, -35.0, 52.0, 20.0),
+    'ssa': (-20.0, -35.0, 52.0, 20.0),
+    'global': (-180.0, -90.0, 180.0, 90.0),
+}
+
+
+def infer_temporal(text: str) -> Tuple[str | None, str | None]:
+    """Extract begin/end timestamps from free-form text.
+
+    Returns a tuple of ISO8601 strings or ``(None, None)`` if no year range is
+    detected.
+    """
+
+    years = [int(y) for y in re.findall(r"((?:19|20)\d{2})", text)]
+    if len(years) >= 2:
+        years.sort()
+        start = datetime(years[0], 1, 1).strftime('%Y-%m-%dT%H:%M:%SZ')
+        end = datetime(years[-1], 12, 31, 23, 59, 59).strftime('%Y-%m-%dT%H:%M:%SZ')
+        return start, end
+    return None, None
+
+
+def infer_bbox(text: str) -> Tuple[float, float, float, float] | None:
+    """Return a bounding box for known regions inside ``text``."""
+
+    lowered = text.lower()
+    for key, bbox in REGION_TO_BBOX.items():
+        if key in lowered:
+            return bbox
+    return None
+

--- a/cmr_agent/vectordb.py
+++ b/cmr_agent/vectordb.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 from typing import Iterable, List, Dict, Any
 import os
-import os
-os.environ.setdefault('CHROMA_TELEMETRY_ENABLED','false')
 import chromadb
 from chromadb.config import Settings as ChromaSettings
 from cmr_agent.config import settings
@@ -11,7 +9,9 @@ class ChromaStore:
     def __init__(self, collection_name: str = 'nasa_docs'):
         persist_dir = settings.vector_db_dir
         os.makedirs(persist_dir, exist_ok=True)
-        self.client = chromadb.Client(ChromaSettings(persist_directory=persist_dir))
+        self.client = chromadb.Client(
+            ChromaSettings(persist_directory=persist_dir, anonymized_telemetry=False)
+        )
         self.collection = self.client.get_or_create_collection(collection_name)
 
     def add_texts(self, ids: List[str], texts: List[str], metadatas: List[Dict[str, Any]] | None = None):

--- a/server/main.py
+++ b/server/main.py
@@ -1,30 +1,42 @@
 from __future__ import annotations
-import asyncio
-from fastapi import FastAPI, HTTPException
+from contextlib import asynccontextmanager
+from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 from cmr_agent.graph.pipeline import build_graph
 
-app = FastAPI(title='NASA CMR AI Agent')
 
-@app.on_event('startup')
-def on_startup():
+SESSIONS: dict[str, list[str]] = {}
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     global APP_GRAPH
     APP_GRAPH = build_graph()
+    yield
 
-async def run_query_stream(user_query: str):
-    state = {'user_query': user_query}
+
+app = FastAPI(title='NASA CMR AI Agent', lifespan=lifespan)
+
+async def run_query_stream(user_query: str, session_id: str | None):
+    history = SESSIONS.get(session_id, []) if session_id else []
+    state = {'user_query': user_query, 'history': history}
     try:
         async for event in APP_GRAPH.astream(state):
             yield (str(event) + '\n').encode('utf-8')
     except Exception as e:
         yield (f"ERROR: {e}\n").encode('utf-8')
+    finally:
+        if session_id is not None:
+            SESSIONS[session_id] = state.get('history', history)
 
 @app.get('/stream')
-async def stream(query: str):
-    return StreamingResponse(run_query_stream(query), media_type='text/event-stream')
+async def stream(query: str, session_id: str | None = None):
+    return StreamingResponse(run_query_stream(query, session_id), media_type='text/event-stream')
 
 @app.get('/query')
-async def query(query: str):
-    graph = build_graph()
-    result = await graph.ainvoke({'user_query': query})
+async def query(query: str, session_id: str | None = None):
+    history = SESSIONS.get(session_id, []) if session_id else []
+    result = await APP_GRAPH.ainvoke({'user_query': query, 'history': history})
+    if session_id is not None:
+        SESSIONS[session_id] = result.get('history', history)
     return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+os.environ.pop('OPENAI_API_KEY', None)
+os.environ.pop('ANTHROPIC_API_KEY', None)

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -1,0 +1,162 @@
+import pytest
+from fastapi.testclient import TestClient
+import cmr_agent.graph.pipeline as pipeline
+from cmr_agent.utils import infer_temporal, infer_bbox
+import server.main as m
+
+
+def test_infer_temporal_and_bbox():
+    start, end = infer_temporal("rainfall 2010-2012 over sub-saharan africa")
+    assert start == "2010-01-01T00:00:00Z"
+    assert end == "2012-12-31T23:59:59Z"
+    bbox = infer_bbox("Datasets for Sub-Saharan Africa")
+    assert bbox == (-20.0, -35.0, 52.0, 20.0)
+
+
+@pytest.mark.asyncio
+async def test_cmr_agent_uses_variables(monkeypatch):
+    calls = {"variables": 0}
+
+    class DummyClient:
+        async def search_collections(self, params):
+            return {"items": []}
+
+        async def search_granules(self, params):
+            return {"items": []}
+
+        async def search_variables(self, params):
+            calls["variables"] += 1
+            return {"items": []}
+
+        async def close(self):
+            pass
+
+    agent = pipeline.CMRAgent()
+    agent.client = DummyClient()
+    await agent.run("rain", [])
+    await agent.close()
+    assert calls["variables"] == 1
+
+
+@pytest.mark.asyncio
+async def test_analysis_temporal_coverage():
+    from cmr_agent.agents.analysis_agent import AnalysisAgent
+
+    cmr_results = {
+        "searches": [
+            {
+                "query": "test",
+                "collections": {"items": []},
+                "granules": {
+                    "items": [
+                        {
+                            "umm": {
+                                "TemporalExtent": {
+                                    "RangeDateTime": {
+                                        "BeginningDateTime": "2020-01-01T00:00:00Z",
+                                        "EndingDateTime": "2020-01-10T00:00:00Z",
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "umm": {
+                                "TemporalExtent": {
+                                    "RangeDateTime": {
+                                        "BeginningDateTime": "2020-01-05T00:00:00Z",
+                                        "EndingDateTime": "2020-01-20T00:00:00Z",
+                                    }
+                                }
+                            }
+                        },
+                    ]
+                },
+                "variables": {"items": []},
+            }
+        ]
+    }
+    agent = AnalysisAgent()
+    summary = await agent.run(cmr_results)
+    coverage = summary["queries"][0]["temporal_coverage"]
+    assert coverage["start"] == "2020-01-01"
+    assert coverage["end"] == "2020-01-20"
+
+
+@pytest.mark.asyncio
+async def test_analysis_spatial_extent():
+    from cmr_agent.agents.analysis_agent import AnalysisAgent
+
+    cmr_results = {
+        "searches": [
+            {
+                "query": "test",
+                "collections": {"items": []},
+                "granules": {
+                    "items": [
+                        {
+                            "umm": {
+                                "SpatialExtent": {
+                                    "HorizontalSpatialDomain": {
+                                        "Geometry": {
+                                            "BoundingBox": {
+                                                "WestBoundingCoordinate": -10,
+                                                "SouthBoundingCoordinate": -5,
+                                                "EastBoundingCoordinate": 5,
+                                                "NorthBoundingCoordinate": 10,
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "umm": {
+                                "SpatialExtent": {
+                                    "HorizontalSpatialDomain": {
+                                        "Geometry": {
+                                            "BoundingBox": {
+                                                "WestBoundingCoordinate": -15,
+                                                "SouthBoundingCoordinate": 0,
+                                                "EastBoundingCoordinate": 10,
+                                                "NorthBoundingCoordinate": 12,
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                    ]
+                },
+                "variables": {"items": []},
+            }
+        ]
+    }
+    agent = AnalysisAgent()
+    summary = await agent.run(cmr_results)
+    bbox = summary["queries"][0]["spatial_extent"]["bbox"]
+    assert bbox == [-15.0, -5.0, 10.0, 12.0]
+
+
+def test_session_memory_persists(monkeypatch):
+    class DummyRetrievalAgent:
+        def __init__(self, *args, **kwargs):
+            self.store = type("S", (), {"similarity_search": lambda self, q, k=5: []})()
+
+        async def run(self, query: str, k: int = 5):
+            return []
+
+    class DummyCMR:
+        async def run(self, query: str, subqueries):
+            return {"searches": []}
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(pipeline, "RetrievalAgent", DummyRetrievalAgent)
+    monkeypatch.setattr(pipeline, "CMRAgent", DummyCMR)
+
+    with TestClient(m.app) as client:
+        r1 = client.get("/query", params={"query": "first", "session_id": "abc"})
+        assert r1.json()["history"] == ["first"]
+        r2 = client.get("/query", params={"query": "second", "session_id": "abc"})
+        assert r2.json()["history"] == ["first", "second"]

--- a/tests/test_enhancements.py
+++ b/tests/test_enhancements.py
@@ -1,0 +1,65 @@
+import os
+from fastapi.testclient import TestClient
+import chromadb
+import server.main as m
+from cmr_agent.config import Settings
+from cmr_agent.vectordb import ChromaStore
+import cmr_agent.graph.pipeline as pipeline
+
+
+def test_default_provider_all(monkeypatch):
+    monkeypatch.delenv('CMR_PROVIDER', raising=False)
+    s = Settings()
+    assert s.cmr_provider == 'ALL'
+
+
+def test_query_reuses_app_graph(monkeypatch):
+    calls = {'count': 0}
+    orig_build = m.build_graph
+
+    def counting_build_graph():
+        calls['count'] += 1
+        return orig_build()
+
+    monkeypatch.setattr(m, 'build_graph', counting_build_graph)
+
+    class DummyStore:
+        def similarity_search(self, query, k=5):
+            return []
+
+    class DummyRetrievalAgent:
+        def __init__(self, *args, **kwargs):
+            self.store = DummyStore()
+
+        async def run(self, query: str, k: int = 5):
+            return []
+
+    monkeypatch.setattr(pipeline, 'RetrievalAgent', DummyRetrievalAgent)
+
+    with TestClient(m.app) as client:
+        assert calls['count'] == 1
+        resp = client.get('/query', params={'query': 'social security'})
+        assert resp.status_code == 200
+        assert calls['count'] == 1
+
+
+def test_chroma_telemetry_disabled(monkeypatch):
+    captured = {}
+
+    class DummyClient:
+        def __init__(self, settings):
+            captured['settings'] = settings
+
+        def get_or_create_collection(self, name):
+            class DummyCollection:
+                def add(self, ids, documents, metadatas=None):
+                    pass
+
+                def query(self, query_texts, n_results):
+                    return {'ids': [[]], 'documents': [[]], 'metadatas': [[]]}
+
+            return DummyCollection()
+
+    monkeypatch.setattr(chromadb, 'Client', DummyClient)
+    store = ChromaStore('test')
+    assert captured['settings'].anonymized_telemetry is False

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,9 +1,22 @@
 import asyncio
 import pytest
+import cmr_agent.graph.pipeline as pipeline
 from cmr_agent.graph.pipeline import build_graph
 
 @pytest.mark.asyncio
-async def test_graph_runs():
+async def test_graph_runs(monkeypatch):
+  class DummyStore:
+    def similarity_search(self, query, k=5):
+      return []
+
+  class DummyRetrievalAgent:
+    def __init__(self, *args, **kwargs):
+      self.store = DummyStore()
+
+    async def run(self, query: str, k: int = 5):
+      return []
+
+  monkeypatch.setattr(pipeline, 'RetrievalAgent', DummyRetrievalAgent)
   graph = build_graph()
-  res = await graph.ainvoke({'user_query': 'Find MODIS aerosol datasets 2020 global'})
+  res = await graph.ainvoke({'user_query': 'social security'})
   assert 'synthesis' in res


### PR DESCRIPTION
## Summary
- default CMR provider expanded to `ALL` and docs updated
- FastAPI `/query` endpoint now reuses the startup-compiled graph via lifespan
- disable Chroma anonymized telemetry to silence warnings
- add tests covering config default, graph reuse, and telemetry settings
- remove unused imports and redundant telemetry env tweak
- augment query handling with temporal/spatial inference and per-session history
- extend CMR agent to include variables, and analysis now reports temporal coverage, related collections, and spatial extent
- enrich synthesis with coverage details and history awareness, plus tests for new features

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895323a00748320adc82822374fd24b