### PR TITLE
Improve handling of empty CMR analysis results

### DIFF
--- a/cmr_agent/agents/analysis_agent.py
+++ b/cmr_agent/agents/analysis_agent.py
@@ -217,16 +217,17 @@ class AnalysisAgent:
             res_score = 1.0 if resolutions else 0.0
             score = (t_days / 365.0) * 0.5 + s_iou * 0.3 + res_score * 0.2
 
+            has_data = bool(cols or grans or vars)
             quality = {
                 'spatial_res_km': float(resolutions[0]) if resolutions else None,
-                'temporal_res': 'hourly',
+                'temporal_res': 'hourly' if has_data else None,
                 'coverage': {
-                    'temporal_pct': 100.0,
-                    'spatial_pct': round(s_iou * 100, 1),
+                    'temporal_pct': 100.0 if has_data else 0.0,
+                    'spatial_pct': round(s_iou * 100, 1) if has_data else 0.0,
                 },
-                'completeness_score': 0.86,
-                'suitability_for_task': round(score, 3),
-                'tradeoffs': ['coarse grid vs long record'],
+                'completeness_score': 0.86 if has_data else 0.0,
+                'suitability_for_task': round(score, 3) if has_data else 0.0,
+                'tradeoffs': ['coarse grid vs long record'] if has_data else [],
             }
             gaps = {
                 'missing_dates': [f"{g['gap_start']}:{g['gap_end']}" for g in temporal_gaps],

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -138,6 +138,29 @@ async def test_analysis_spatial_extent():
     assert bbox == [-15.0, -5.0, 10.0, 12.0]
 
 
+@pytest.mark.asyncio
+async def test_analysis_handles_empty_results():
+    from cmr_agent.agents.analysis_agent import AnalysisAgent
+
+    cmr_results = {
+        "searches": [
+            {
+                "query": "test",
+                "collections": {"items": []},
+                "granules": {"items": []},
+                "variables": {"items": []},
+            }
+        ]
+    }
+    agent = AnalysisAgent()
+    summary = await agent.run(cmr_results)
+    q = summary["queries"][0]["quality"]
+    assert q["temporal_res"] is None
+    assert q["coverage"]["temporal_pct"] == 0.0
+    assert q["completeness_score"] == 0.0
+    assert q["tradeoffs"] == []
+
+
 def test_session_memory_persists(monkeypatch):
     class DummyRetrievalAgent:
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- Avoid placeholder quality metrics when CMR searches return no collections, granules, or variables
- Add regression test verifying analysis output for empty result sets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68977bbf7cf08320851c861f5b0b862f